### PR TITLE
Build hpi path from artifact metadata instead of preserving the structure from -hpiDirectory

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/LocalDirectoryRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/LocalDirectoryRepository.java
@@ -52,16 +52,18 @@ public class LocalDirectoryRepository extends MavenRepository
     private File dir;
     private URL baseUrl;
     private final boolean includeSnapshots;
+    private final File downloadDir;
     
     /**
      * @param dir a directory containing HPI files.
      * @param includeSnapshots 
      */
-    public LocalDirectoryRepository(File dir, URL baseUrl, boolean includeSnapshots)
+    public LocalDirectoryRepository(File dir, URL baseUrl, boolean includeSnapshots, File downloadDir)
     {
         this.dir = dir;
         this.baseUrl = baseUrl;
         this.includeSnapshots = includeSnapshots;
+        this.downloadDir = downloadDir;
     }
     
     /**
@@ -121,7 +123,23 @@ public class LocalDirectoryRepository extends MavenRepository
             if (p==null)
                 plugins.put(a.artifactId, p=new PluginHistory(a.artifactId));
             
-            p.addArtifact(new LocalHPI(this, p, a, hpiFile, baseUrl));
+            URL url;
+            if (downloadDir == null) {
+
+                String path = filename;
+                if(File.separatorChar != '/')
+                {
+                    // fix path separate character to /
+                    path = filename.replace(File.separatorChar, '/');
+                }
+                url = new URL(baseUrl, path);
+            } else {
+
+                // Build path using artifact metadata
+                final String path = new LocalHPI(this, p, a, hpiFile, null).getRelativePath();
+                url = new URL(baseUrl, "download/" + path);
+            }
+            p.addArtifact(new LocalHPI(this, p, a, hpiFile, url));
             p.groupId.add(a.groupId);
         }
         

--- a/src/main/java/org/jvnet/hudson/update_center/LocalHPI.java
+++ b/src/main/java/org/jvnet/hudson/update_center/LocalHPI.java
@@ -43,7 +43,7 @@ import org.sonatype.nexus.index.ArtifactInfo;
 public class LocalHPI extends HPI
 {
     private File jarFile;
-    private URL baseUrl;
+    private URL url;
     
     public LocalHPI(
             MavenRepository repository,
@@ -55,13 +55,13 @@ public class LocalHPI extends HPI
     {
         super(repository, history, artifact);
         this.jarFile = jarFile;
-        this.baseUrl = url;
+        this.url = url;
     }
     
     @Override
     public URL getURL() throws MalformedURLException
     {
-        return new URL(baseUrl, "download/" + getRelativePath());
+        return url;
     }
     
     @Override

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -251,8 +251,8 @@ public class Main {
         {
             throw new Exception("-repository must be specified when using hpiDiretoryPath.");
         }
-        
-        return new LocalDirectoryRepository(hpiDirectory, new URL(repository), includeSnapshots);
+
+        return new LocalDirectoryRepository(hpiDirectory, new URL(repository), includeSnapshots, download);
     }
 
     /**


### PR DESCRIPTION
This is more robust solution as it can deal with malformed hierarchy in -hpiDirectory. Last but not least it can generate download structure from flat directory of plugin files.
