### PR TITLE
Fix NPE caused by empty Group-Id entry in MANIFEST.MF

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/LocalDirectoryRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/LocalDirectoryRepository.java
@@ -95,11 +95,18 @@ public class LocalDirectoryRepository extends MavenRepository
             Manifest manifest = jar.getManifest();
             long lastModified = jar.getEntry("META-INF/MANIFEST.MF").getTime();
             jar.close();
+
+            String groupId = manifest.getMainAttributes().getValue("Group-Id");
+            if (groupId == null) {
+                // Old plugins inheriting from org.jvnet.hudson.plugins do not have
+                // Group-Id field set in manifest. Absence of group id causes NPE in ArtifactInfo.
+                groupId = "org.jvnet.hudson.plugins";
+            }
             
             ArtifactInfo a = new ArtifactInfo(
                     null,  // fname
                     "hpi",  // fextension
-                    manifest.getMainAttributes().getValue("Group-Id"), // groupId,
+                    groupId,
                     manifest.getMainAttributes().getValue("Extension-Name"),    // artifactId
                         // maybe Short-Name or Implementation-Title is more proper.
                     manifest.getMainAttributes().getValue("Plugin-Version"),    // version


### PR DESCRIPTION
Ancient plugins (such as locks-and-latches-plugin) do not have this fields set. Use "org.jvnet.hudson.plugins" as a default.

```
java.lang.NullPointerException
    at org.jvnet.hudson.update_center.HPI.isAuthenticJenkinsArtifact(HPI.java:235)
    at org.jvnet.hudson.update_center.PluginHistory.findYoungestJenkinsArtifact(PluginHistory.java:102)
    at org.jvnet.hudson.update_center.PluginHistory.addArtifact(PluginHistory.java:86)
    at org.jvnet.hudson.update_center.LocalDirectoryRepository.listHudsonPlugins(LocalDirectoryRepository.java:143)
    at org.jvnet.hudson.update_center.Main.buildPlugins(Main.java:269)
    at org.jvnet.hudson.update_center.Main.buildUpdateCenterJson(Main.java:199)
    at org.jvnet.hudson.update_center.Main.run(Main.java:163)
    at org.jvnet.hudson.update_center.Main.run(Main.java:140)
    at org.jvnet.hudson.update_center.Main.main(Main.java:127)
```
