### PR TITLE
Fixed offline capability

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -262,6 +262,7 @@ public class Main {
      */
     protected JSONObject buildPlugins(MavenRepository repository, PrintWriter redirect) throws Exception {
         ConfluencePluginList cpl = nowiki?new NoConfluencePluginList():new ConfluencePluginList();
+        cpl.initialize();
 
         int total = 0;
 
@@ -360,6 +361,7 @@ public class Main {
 
     protected JSONArray buildReleaseHistory(MavenRepository repository) throws Exception {
         ConfluencePluginList cpl = nowiki?new NoConfluencePluginList():new ConfluencePluginList();
+        cpl.initialize();
 
         JSONArray releaseHistory = new JSONArray();
         for( Map.Entry<Date,Map<String,HPI>> relsOnDate : repository.listHudsonPluginsByReleaseDate().entrySet() ) {

--- a/src/main/java/org/jvnet/hudson/update_center/NoConfluencePluginList.java
+++ b/src/main/java/org/jvnet/hudson/update_center/NoConfluencePluginList.java
@@ -36,8 +36,10 @@ import javax.xml.rpc.ServiceException;
  */
 public class NoConfluencePluginList extends ConfluencePluginList
 {
-    public NoConfluencePluginList() throws IOException, ServiceException
-    {
+    
+    @Override
+    public void initialize() throws IOException, ServiceException {
+    	// noop
     }
     
     @Override


### PR DESCRIPTION
If no internet connection is available for whatever reason (e.g. proxy not configured) or is unwanted to be used, the parameter "-nowiki" will be used. However, the NoConfluencePluginList class inherits from ConfluencePluginList, which tries connecting to the Confluence server in its constructor. As this is the default constructor, it gets called also when creating subclasses. This leads to an "Unknown Host" exception or similar, which is totally unneccessary as the server actually should not be used anyway.

By extracting the logic from the default constructor into the "initialize()" method I have resolved this issue. The methods in ConfluencePluginList that rely on this initialization are guarded by "checkInitialized()".
