### PR TITLE
Fix #16: Handle plugins without pom.xml in hpi.

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/LocalHPI.java
+++ b/src/main/java/org/jvnet/hudson/update_center/LocalHPI.java
@@ -73,21 +73,43 @@ public class LocalHPI extends HPI
     @Override
     public File resolvePOM() throws IOException
     {
-        JarFile jar = new JarFile(jarFile);
-        String pomPath = String.format("META-INF/maven/%s/%s/pom.xml", artifact.groupId, artifact.artifactId);
-        ZipEntry e = jar.getEntry(pomPath);
-        
-        File temporaryFile = File.createTempFile(artifact.artifactId, ".xml");
-        temporaryFile.deleteOnExit();
-        
-        InputStream in = jar.getInputStream(e);
-        OutputStream out = new FileOutputStream(temporaryFile);
-        
-        IOUtils.copy(in, out);
-        
-        out.close();
-        in.close();
-        jar.close();
-        return temporaryFile;
+        JarFile jar = null;
+        InputStream in = null;
+        OutputStream out = null;
+        try
+        {
+            jar = new JarFile(jarFile);
+            String pomPath = String.format("META-INF/maven/%s/%s/pom.xml", artifact.groupId, artifact.artifactId);
+            ZipEntry e = jar.getEntry(pomPath);
+            if (e == null)
+            {
+                return null;
+            }
+            
+            File temporaryFile = File.createTempFile(artifact.artifactId, ".xml");
+            temporaryFile.deleteOnExit();
+            
+            in = jar.getInputStream(e);
+            out = new FileOutputStream(temporaryFile);
+            
+            IOUtils.copy(in, out);
+            
+            return temporaryFile;
+        }
+        finally
+        {
+            if (out != null)
+            {
+                out.close();
+            }
+            if (in != null)
+            {
+                in.close();
+            }
+            if (jar != null)
+            {
+                jar.close();
+            }
+        }
     }
 }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -305,7 +305,7 @@ public class Plugin {
 
     public String getTitle() {
         String title = page != null ? page.getTitle() : null;
-        if (title == null)
+        if (title == null && pom != null)
             title = selectSingleValue(pom, "/project/name");
         if (title == null)
             title = artifactId;


### PR DESCRIPTION
#16
Some plugins (especially plugins build with gradle) doesn't contain pom.xml.
This change allows those plugins (backend-update-center2 originally allows plugins without pom.xml)