### PR TITLE
Add Temp File Prefix

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/LocalHPI.java
+++ b/src/main/java/org/jvnet/hudson/update_center/LocalHPI.java
@@ -42,6 +42,8 @@ import org.sonatype.nexus.index.ArtifactInfo;
  */
 public class LocalHPI extends HPI
 {
+    private final static String TEMP_PREFIX = "uc_";
+
     private File jarFile;
     private URL url;
     
@@ -86,7 +88,7 @@ public class LocalHPI extends HPI
                 return null;
             }
             
-            File temporaryFile = File.createTempFile(artifact.artifactId, ".xml");
+            File temporaryFile = File.createTempFile(TEMP_PREFIX + artifact.artifactId, ".xml");
             temporaryFile.deleteOnExit();
             
             in = jar.getInputStream(e);


### PR DESCRIPTION
Added a prefix for temp files to ensure that the length of the prefix is greater than the required 3 characters.

Prior to this, index generation would fail on plugin names that were shorter than three characters, such as p4.