### PR TITLE
Generate update-center.actual.json as well

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -56,8 +56,11 @@ import java.util.TreeMap;
  * @author Kohsuke Kawaguchi
  */
 public class Main {
-    @Option(name="-o",usage="json file")
-    public File output = new File("output.json");
+    @Option(name="-o",usage="JSONP file")
+    public File jsonp = new File("output.json");
+
+    @Option(name="-json",usage="JSON file")
+    public File json = new File("actual.json");
 
     @Option(name="-r",usage="release history JSON file")
     public File releaseHistory = new File("release-history.json");
@@ -153,7 +156,8 @@ public class Main {
     }
 
     private void prepareStandardDirectoryLayout() {
-        output = new File(www,"update-center.json");
+        json = new File(www,"update-center.actual.json");
+        jsonp = new File(www,"update-center.json");
         htaccess = new File(www,"latest/.htaccess");
         indexHtml = new File(www,"index.html");
         releaseHistory = new File(www,"release-history.json");
@@ -167,8 +171,9 @@ public class Main {
         PrintWriter latestRedirect = createHtaccessWriter();
 
         JSONObject ucRoot = buildUpdateCenterJson(repo, latestRedirect);
-        writeToFile(updateCenterPostCallJson(ucRoot), output);
-        writeToFile(updateCenterPostMessageHtml(ucRoot), new File(output.getPath()+".html"));
+        writeToFile(updateCenterPostCallJson(ucRoot), jsonp);
+        writeToFile(prettyPrintJson(ucRoot), json);
+        writeToFile(updateCenterPostMessageHtml(ucRoot), new File(jsonp.getPath()+".html"));
 
         JSONObject rhRoot = buildFullReleaseHistory(repo);
         String rh = prettyPrintJson(rhRoot);


### PR DESCRIPTION
This as taking changes from upstream. The codebases have diverged so much that `git cherry-pick` have done more harm than good. It is essentially:

- https://github.com/jenkins-infra/update-center2/commit/a42b1f396957bb3ff0f25ea2d2c24e42387c6a2d
- https://github.com/jenkins-infra/update-center2/commit/9bfc7c72ce308af5f14140495924702fd493a889

The motivation here is to get the update center resolvable by https://github.com/jenkinsci/plugin-installation-manager-tool that only read the `update-center.actual.json`.