### PR TITLE
Changed http to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   


### PR DESCRIPTION
**maven compile** fails because of error 308. Changing http to https solves the problem.