### PR TITLE
Make buildable on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,16 @@
           <mainClass>${main.class}</mainClass>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -169,7 +169,7 @@ public class MavenRepositoryImpl extends MavenRepository {
 
         URLConnection con = url.openConnection();
         if (url.getUserInfo()!=null) {
-            con.setRequestProperty("Authorization","Basic "+new sun.misc.BASE64Encoder().encode(url.getUserInfo().getBytes()));
+            con.setRequestProperty("Authorization","Basic " + java.util.Base64.getEncoder().encodeToString(url.getUserInfo().getBytes()));
         }
 
         if (!expanded.exists() || !local.exists() || (local.lastModified()!=con.getLastModified() && !offlineIndex)) {


### PR DESCRIPTION
javac in v11 dropped support for java 5 source/target.

```
 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project update-center2: Compilation failure: Compilation failure: 
 [ERROR] error: Source option 5 is no longer supported. Use 6 or later.
 [ERROR] error: Target option 1.5 is no longer supported. Use 1.6 or later.
```

Advancing it even to v6 caused the `new sun.misc.BASE64Encoder` to be missing. So moving all the way to v8.